### PR TITLE
readme:add more dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Norman is light weight and runs on small hardware specs. Add it to your Raspberr
 
 Python 3 or Python 2.7 with linked libraries (easiest is to install Python 3)
 - Mac: `brew upgrade python`
-- Linux: `sudo apt-get install python python-dev`
+- Linux: `sudo apt-get install python python-dev autoconf libtool`
 
 **Recording program installation:**
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Norman is light weight and runs on small hardware specs. Add it to your Raspberr
 
 Python 3 or Python 2.7 with linked libraries (easiest is to install Python 3)
 - Mac: `brew upgrade python`
-- Linux: `sudo apt-get install python python-dev autoconf libtool`
+- Linux: `sudo apt-get install python python-dev autoconf libtool swig`
 
 **Recording program installation:**
 


### PR DESCRIPTION
On Debian Linux 9, the autoconf and libtool package is needed (selecting
to install autoconf will also install automake).